### PR TITLE
Handle programmes without listing gracefully

### DIFF
--- a/bbc_tracklist.py
+++ b/bbc_tracklist.py
@@ -52,7 +52,12 @@ def open_listing_page(trailing_part_of_url):
         print("Check network connection and/or programme id.")
         sys.exit(1)
 
-    return lxml.html.fromstring(html)
+    try:
+        return lxml.html.fromstring(html)
+    except lxml.etree.ParserError:
+        print("Error trying to parse web page.")
+        print("Maybe there's no programme listing?")
+        sys.exit(1)
 
 
 def get_programme_title(pid):


### PR DESCRIPTION
For example, http://www.bbc.co.uk/programmes/b04hszvm

Accessing broadcasts.inc in this case just gave a whitespace containing
string as the HTML, and a horrible looking traceback for the user.
