### PR TITLE
Switch underscore to hyphens in setup.py name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ here = path.abspath(path.dirname(__file__))
 #   long_description = f.read()
 
 setup(
-    name='bbc_radio_tracklisting_downloader',
+    name='bbc-radio-tracklisting-downloader',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see


### PR DESCRIPTION
Consistent with PyPI and now the repository (which was renamed).