### PR TITLE
Version bump after changing name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.1',
+    version='0.0.2',
     py_modules=['bbc_tracklist', 'cmdline'],
     description='Download BBC radio show tracklistings',
     #long_description=long_description,


### PR DESCRIPTION
From 0.0.1 to 0.0.2, carried out in case there's any confusion over
underscores/hyphens when installing/uninstalling. (Not sure what the
behaviour of PyPI is on that.)