### PR TITLE
Update setup.py for 0.0.3 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.2',
+    version='0.0.3',
     py_modules=['bbc_tracklist', 'cmdline'],
     description='Download BBC radio show tracklistings',
     #long_description=long_description,


### PR DESCRIPTION
Python 3.6 is out, but not 100% sure that mediafile supports it, so have
left the versions intact here.